### PR TITLE
Added URL encoding for user and password

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,9 +29,9 @@ app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'ejs');
 
 async function authenticate() {
-  process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = 0;
+  process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = 0; 
   const authResponse = await fetch(
-    `https://${ip}/photo/webapi/auth.cgi?api=SYNO.API.Auth&version=3&method=login&account=${user}&passwd=${password}`
+    `https://${ip}/photo/webapi/auth.cgi?api=SYNO.API.Auth&version=3&method=login&account=${encodeURIComponent(user)}&passwd=${encodeURIComponent(password)}`
   )
   process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = 1;
   const authData = await authResponse.json()


### PR DESCRIPTION
Ensures that all non-safe characters are properly encoded, making it suitable for use in URL parameters.
 This will fix errors with password like: "123&456" where the password in the query was read as 123.